### PR TITLE
snap: workaround for core24 build with explicit build-base

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -19,6 +19,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: snapcore/action-build@v1
       id: snapcraft
+      with:
+        # edge has a fix for https://bugs.launchpad.net/snapcraft/+bug/2051567
+        snapcraft-channel: latest/edge
     - uses: actions/upload-artifact@v3
       with:
         name: snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,12 +1,13 @@
 name: console-conf
 base: core24
+build-base: devel
 summary: console-conf Ubuntu Core first boot experience
 description: |
   console-conf provide device onboarding experience for
   Ubuntu Core systems. User can configure network and
   assume ownership of the system.
 
-grade: stable
+grade: devel
 confinement: strict
 adopt-info: subiquity
 


### PR DESCRIPTION
Since 24.04 and core24 have not been released yet, snapcraft needs an explicit `build-base: devel` to be declared.