### PR TITLE
snap: fix dependencies when building for core24, TODOs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,9 @@ apps:
       - run-console-conf
       - snapd-control
 
+# TODO build probert and console-conf as debs so that dependencies are pulled in
+# automatically
+
 parts:
   probert:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -94,23 +94,26 @@ parts:
   python:
     plugin: nil
     stage-packages:
-      - libpython3-stdlib
-      - libpython3.11-minimal
-      - libpython3.11-stdlib
-      - libsystemd0
       - python3
-      - python3.11-minimal
+      - python3-minimal
+      - python3.12-minimal
+      - libpython3-stdlib
+      - libpython3.12-stdlib
+      - libpython3.12-minimal
+      - libsystemd0
       - python3-aiohttp
       - python3-apport
       - python3-attr
       - python3-bson
-      - python3-chardet
       - python3-certifi
+      - python3-chardet
       - python3-debian
       - python3-idna
       - python3-jsonschema
       - python3-minimal
+      - python3-multidict
       - python3-oauthlib
+      - python3-openssl
       - python3-pkg-resources
       - python3-pyroute2
       - python3-pyrsistent
@@ -119,8 +122,10 @@ parts:
       - python3-requests-unixsocket
       - python3-six
       - python3-systemd
+      - python3-typing-extensions
       - python3-urllib3
       - python3-urwid
+      - python3-wcwidth
       - python3-yaml
       - python3-yarl
 


### PR DESCRIPTION
Since core24 has been updated with python 3.12, dependencies need an update.

The build process should really be improved to just build a deb package of both and let apt figure this out, and then we can trim the list of installed files manually rather than hunting for pacakges.