### PR TITLE
github: split PR and push workflows, publish to store from master

### DIFF
--- a/.github/workflows/snap-build-publish.yaml
+++ b/.github/workflows/snap-build-publish.yaml
@@ -1,0 +1,39 @@
+name: Snap build
+
+on:
+  push:
+    branches:
+      - main
+  # manual
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: snapcore/action-build@v1
+      id: build
+      with:
+        # edge has a fix for https://bugs.launchpad.net/snapcraft/+bug/2055322
+        snapcraft-channel: latest/edge
+
+    # upload the artifact if further inspection is needed
+    - uses: actions/upload-artifact@v3
+      with:
+        name: snap
+        path: ${{ steps.build.outputs.snap }}
+        retention-days: 5
+
+    # publish to store and release
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        # release to latest/edge/main
+        release: edge/main

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,15 +1,12 @@
-name: Snap build
+name: Snap test build
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref || github.run_id }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
@@ -18,12 +15,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: snapcore/action-build@v1
-      id: snapcraft
+      id: build
       with:
-        # edge has a fix for https://bugs.launchpad.net/snapcraft/+bug/2051567
+        # edge has a fix for https://bugs.launchpad.net/snapcraft/+bug/2055322
         snapcraft-channel: latest/edge
+
     - uses: actions/upload-artifact@v3
       with:
         name: snap
-        path: ${{ steps.snapcraft.outputs.snap }}
+        path: ${{ steps.build.outputs.snap }}
         retention-days: 5


### PR DESCRIPTION
While waiting for #8 to be green, this branch carries a little refactor of the workflows. The workflow triggered by PRs only builds the snap, while there's a separate workflow only triggered on push, which will build and publish to the store to edge/main branch.