### PR TITLE
snap: drop write-login-details

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,15 +37,6 @@ apps:
   wait:
     command: usr/share/subiquity/console-conf-wait
 
-  write-login-details:
-    command: usr/bin/python3 $SNAP/usr/share/subiquity/console-conf-write-login-details
-    plugs:
-      # TODO: controversial interfaces disabled to enable store uploads
-      - log-observe
-      - network-control
-      # - run-console-conf
-      # - snapd-control
-
 # TODO build probert and console-conf as debs so that dependencies are pulled in
 # automatically
 


### PR DESCRIPTION
Drop the write-login-details app as there's an alternative, unconfined, implementation in https://github.com/snapcore/core-base/pull/187