### PR TITLE
snap: drop unnecessay interfaces, tweak plug names and app plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ apps:
       - network-control
       - network-observe
       - network-setup-control
-      # - run-console-conf
+      # - console-conf-runtime-support
       # - snapd-control
 
   wait:
@@ -145,7 +145,7 @@ parts:
 # TODO: controversial interfaces disabled to enable store uploads
 
 # plugs:
-#   run-console-conf:
+#   console-conf-runtime-support:
 #     interface: system-files
 #     write:
 #       - /run/console-conf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,7 @@ apps:
       - network-observe
       - network-setup-control
       # - console-conf-runtime-support
+      # - terminal-control
       # - snapd-control
 
   wait:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,6 @@ apps:
     plugs:
       # TODO: controversial interfaces disabled to enable store uploads
       - hardware-observe
-      - log-observe
       - network
       - network-control
       - network-observe


### PR DESCRIPTION
Drop `log-observe`, we don't need it for anything. Tweak plug name and explicitly list required plugs for the main app.