### PR TITLE
github: tweak workflow names, add workflow for LP builds and publishign to edge

### DIFF
--- a/.github/workflows/snap-build-publish-edge.yaml
+++ b/.github/workflows/snap-build-publish-edge.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: lp-build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish_to_edge:
     # self-hosted runner so we can access launchpad

--- a/.github/workflows/snap-build-publish-edge.yaml
+++ b/.github/workflows/snap-build-publish-edge.yaml
@@ -1,0 +1,21 @@
+name: Build on LP, run spread tests, publish to edge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish_to_edge:
+    # self-hosted runner so we can access launchpad
+    runs-on: self-hosted
+    steps:
+      - name: Publish to edge
+        env:
+          LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        uses: snapcore/system-snaps-cicd-tools/action-publish-edge@main
+        with:
+          # TODO enable tests once we have them
+          run_tests: false
+          track: "latest"

--- a/.github/workflows/snap-build-publish.yaml
+++ b/.github/workflows/snap-build-publish.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}
+  group: snapcore-build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/snap-build-publish.yaml
+++ b/.github/workflows/snap-build-publish.yaml
@@ -1,4 +1,4 @@
-name: Snap build
+name: Snap build and publish to edge/main (snapcore actions)
 
 on:
   push:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,4 +1,4 @@
-name: Snap test build
+name: Snap test build (snapcore actions)
 
 on:
   pull_request:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}-${{ github.event_name }}
+  group: snapcore-build-${{ github.head_ref || github.run_id }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-${{ github.event_name }}
+  # TODO: how to cancel LP job?
+  cancel-in-progress: true
+
 jobs:
   build:
     timeout-minutes: 720

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}-${{ github.event_name }}
+  group: lp-build-${{ github.head_ref || github.run_id }}-${{ github.event_name }}
   # TODO: how to cancel LP job?
   cancel-in-progress: true
 


### PR DESCRIPTION
Add new workflow which does an LP build, runs spread tests and publishes to edge. Tweak other workflow names.

Depends on https://github.com/snapcore/system-snaps-cicd-tools/pull/6