### PR TITLE
github: temporarily skip riscv64 builds

### DIFF
--- a/.github/workflows/snap-build-publish-edge.yaml
+++ b/.github/workflows/snap-build-publish-edge.yaml
@@ -23,3 +23,6 @@ jobs:
           # TODO enable tests once we have them
           run_tests: false
           track: "latest"
+          # add riscv64 once we have a core24 snap for it, see
+          # https://launchpad.net/~ubuntu-core-service/+snap/core24
+          architectures: arm64,amd64,armhf


### PR DESCRIPTION
Since riscv64 builds keep failing, disable them for now.