### PR TITLE
snap: adjust plug names and enable all required plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,10 +30,10 @@ apps:
       - network-control
       - network-observe
       - network-setup-control
-      # - run-console-conf
-      # - var-log-console-conf
-      # - terminal-control
-      # - snapd-control
+      - run-console-conf
+      - var-log-console-conf
+      - terminal-control
+      - snapd-control
 
   wait:
     command: usr/share/subiquity/console-conf-wait
@@ -145,32 +145,32 @@ parts:
 
 # TODO: controversial interfaces disabled to enable store uploads
 
-# plugs:
-#   run-console-conf:
-#     interface: system-files
-#     write:
-#       - /run/console-conf
-#   var-log-console-conf:
-#     interface: system-files
-#     write:
-#       - /var/log/console-conf
-#   terminal-control:
-#     interface: custom-device
+plugs:
+  run-console-conf:
+    interface: system-files
+    write:
+      - /run/console-conf
+  var-log-console-conf:
+    interface: system-files
+    write:
+      - /var/log/console-conf
+  terminal-control:
+    interface: custom-device
 
-# slots:
-#   terminal-devices:
-#     interface: custom-device
-#     custom-device: terminal-control
-#     # XXX this could use x11/wayland/mir interface, but we only need a subset of
-#     # the permissions provided by each
-#     devices:
-#       - /dev/tty[0-9]
-#       - /dev/ttyS[0-9]
-#     udev-tagging:
-#       - kernel: tty[0-9]
-#         subsystem: tty
-#       - kernel: ttyS[0-9]
-#         subsystem: tty
+slots:
+  terminal-devices:
+    interface: custom-device
+    custom-device: terminal-control
+    # XXX this could use x11/wayland/mir interface, but we only need a subset of
+    # the permissions provided by each
+    devices:
+      - /dev/tty[0-9]
+      - /dev/ttyS[0-9]
+    udev-tagging:
+      - kernel: tty[0-9]
+        subsystem: tty
+      - kernel: ttyS[0-9]
+        subsystem: tty
 
 build-packages:
   - apt-utils

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,8 @@ apps:
       - network-control
       - network-observe
       - network-setup-control
-      # - console-conf-runtime-support
+      # - run-console-conf
+      # - var-log-console-conf
       # - terminal-control
       # - snapd-control
 
@@ -145,10 +146,13 @@ parts:
 # TODO: controversial interfaces disabled to enable store uploads
 
 # plugs:
-#   console-conf-runtime-support:
+#   run-console-conf:
 #     interface: system-files
 #     write:
 #       - /run/console-conf
+#   var-log-console-conf:
+#     interface: system-files
+#     write:
 #       - /var/log/console-conf
 #   terminal-control:
 #     interface: custom-device


### PR DESCRIPTION
Adjust names of plugs using the system-files interface as per https://forum.snapcraft.io/t/allow-installation-and-auto-connection-of-mulitple-interfaces-for-console-conf-snap/39204

Enable all plugs since the required assertions have been granted.