### PR TITLE
snap: drop devel build-base and grade

### DIFF
--- a/.github/workflows/snap-build-publish-edge.yaml
+++ b/.github/workflows/snap-build-publish-edge.yaml
@@ -26,3 +26,4 @@ jobs:
           # https://launchpad.net/~ubuntu-core-service/+snap/core24
           architectures: arm64,amd64,armhf
           spread_suites: "google-nested:"
+          snapcraft_channel: "latest/edge"

--- a/.github/workflows/snap-build-publish-edge.yaml
+++ b/.github/workflows/snap-build-publish-edge.yaml
@@ -22,8 +22,9 @@ jobs:
         with:
           run_tests: true
           track: "latest"
-          # add riscv64 once we have a core24 snap for it, see
+          # TODO add riscv64 once we have a core24 snap for it, see
           # https://launchpad.net/~ubuntu-core-service/+snap/core24
-          architectures: arm64,amd64,armhf
+          # TODO: restore armhf once we have the base snap available
+          architectures: arm64,amd64
           spread_suites: "google-nested:"
           snapcraft_channel: "latest/edge"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,8 +21,9 @@ jobs:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
         uses: snapcore/system-snaps-cicd-tools/action-test@main
         with:
-          # add riscv64 once we have a core24 snap for it, see
+          # TODO: add riscv64 once we have a core24 snap for it, see
           # https://launchpad.net/~ubuntu-core-service/+snap/core24
-          architectures: arm64,amd64,armhf
+          # TODO: restore armhf once we have the base snap available
+          architectures: arm64,amd64
           spread_suites: "google-nested:"
           snapcraft_channel: "latest/edge"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,3 +25,4 @@ jobs:
           # https://launchpad.net/~ubuntu-core-service/+snap/core24
           architectures: arm64,amd64,armhf
           spread_suites: "google-nested:"
+          snapcraft_channel: "latest/edge"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,13 +1,11 @@
 name: console-conf
 base: core24
-build-base: devel
 summary: console-conf Ubuntu Core first boot experience
 description: |
   console-conf provide device onboarding experience for
   Ubuntu Core systems. User can configure network and
   assume ownership of the system.
 
-grade: devel
 confinement: strict
 adopt-info: set-metadata
 


### PR DESCRIPTION
Since core24 has gone into beta, we can drop devel grade and build-base.