### PR TITLE
github: reenable armhf builds

### DIFF
--- a/.github/workflows/snap-build-publish-edge.yaml
+++ b/.github/workflows/snap-build-publish-edge.yaml
@@ -24,7 +24,6 @@ jobs:
           track: "latest"
           # TODO add riscv64 once we have a core24 snap for it, see
           # https://launchpad.net/~ubuntu-core-service/+snap/core24
-          # TODO: restore armhf once we have the base snap available
-          architectures: arm64,amd64
+          architectures: arm64,amd64,armhf
           spread_suites: "google-nested:"
           snapcraft_channel: "latest/edge"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,6 @@ jobs:
         with:
           # TODO: add riscv64 once we have a core24 snap for it, see
           # https://launchpad.net/~ubuntu-core-service/+snap/core24
-          # TODO: restore armhf once we have the base snap available
-          architectures: arm64,amd64
+          architectures: arm64,amd64,armhf
           spread_suites: "google-nested:"
           snapcraft_channel: "latest/edge"


### PR DESCRIPTION
core24 for armhf is avaialable, reenable the snap build.