### PR TITLE
snap: bump revisions of probert and console-conf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,8 +44,8 @@ parts:
     plugin: nil
     source: https://github.com/canonical/probert.git
     source-type: git
-    # following branch server/jammy
-    source-commit: 253acbe1480fba69d12d6e72f53412da79e27410
+    # following branch core/jammy
+    source-commit: 94be2fa3f45e766ecee526fdc0c15f65a78667e6
     override-build: |
       unset LD_FLAGS
       unset LD_LIBRARY_PATH
@@ -67,8 +67,9 @@ parts:
     plugin: nil
     source: https://github.com/canonical/subiquity.git
     source-type: git
-    # https://github.com/canonical/subiquity/commit/0aaade5c53baf53e25dd4dfe8d003dd42cc395e8
-    source-commit: 0aaade5c53baf53e25dd4dfe8d003dd42cc395e8
+    # commit including relicense to GPL3
+    # https://github.com/canonical/subiquity/commit/86bce5c5e27b99df6ce6e79fc457f6f9828247ca
+    source-commit: 86bce5c5e27b99df6ce6e79fc457f6f9828247ca
     override-build: |
       version=$(git describe --tags)
       unset LD_FLAGS


### PR DESCRIPTION
Bump revisions of probert and console-conf to commits in which the source tree has been relicensed to GPL3.