### PR TITLE
.github: use same actions as other system snaps

### DIFF
--- a/.github/workflows/snap-build-publish-edge.yaml
+++ b/.github/workflows/snap-build-publish-edge.yaml
@@ -13,17 +13,10 @@ jobs:
   publish_to_edge:
     # self-hosted runner so we can access launchpad
     runs-on: self-hosted
+    environment: store
     steps:
       - name: Publish to edge
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         uses: snapcore/system-snaps-cicd-tools/action-publish-edge@main
-        with:
-          run_tests: true
-          track: "latest"
-          # TODO add riscv64 once we have a core24 snap for it, see
-          # https://launchpad.net/~ubuntu-core-service/+snap/core24
-          architectures: arm64,amd64,armhf
-          spread_suites: "google-nested:"
-          snapcraft_channel: "latest/edge"

--- a/.github/workflows/snap-build-publish.yaml
+++ b/.github/workflows/snap-build-publish.yaml
@@ -1,39 +1,19 @@
 name: Snap build and publish to edge/main (snapcore actions)
 
-on:
-  push:
-    branches:
-      - main
-  # manual
-  workflow_dispatch:
+# manual
+on: workflow_dispatch
 
 concurrency:
   group: snapcore-build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  build_release:
+    runs-on: self-hosted
+    environment: store
     steps:
-    - uses: actions/checkout@v4
-    - uses: snapcore/action-build@v1
-      id: build
-      with:
-        # edge has a fix for https://bugs.launchpad.net/snapcraft/+bug/2055322
-        snapcraft-channel: latest/edge
-
-    # upload the artifact if further inspection is needed
-    - uses: actions/upload-artifact@v3
-      with:
-        name: snap
-        path: ${{ steps.build.outputs.snap }}
-        retention-days: 5
-
-    # publish to store and release
-    - uses: snapcore/action-publish@v1
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-      with:
-        snap: ${{ steps.build.outputs.snap }}
-        # release to latest/edge/main
-        release: edge/main
+      - name: Build release
+        env:
+          LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        uses: snapcore/system-snaps-cicd-tools/action-release@main

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -20,7 +20,7 @@ jobs:
         # edge has a fix for https://bugs.launchpad.net/snapcraft/+bug/2055322
         snapcraft-channel: latest/edge
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: snap
         path: ${{ steps.build.outputs.snap }}
@@ -36,7 +36,7 @@ jobs:
         rm -rf "${{ github.workspace }}"
         mkdir "${{ github.workspace }}"
     - uses: actions/checkout@v4
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: snap
         path: "${{ github.workspace }}/console-conf-artifact"
@@ -65,7 +65,7 @@ jobs:
             mv -v "$f" "${f//:/-}"
         done
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-artifacts


### PR DESCRIPTION
Use the same actions as bluez and other system snap for publishing to edge and beta channels.