### PR TITLE
snapcraft.yaml: move version calculation after package build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: console-conf
 base: core26
-build-base: devel
 summary: console-conf Ubuntu Core first boot experience
 description: |
   console-conf provide device onboarding experience for
@@ -8,7 +7,7 @@ description: |
   assume ownership of the system.
 
 confinement: strict
-grade: devel
+grade: stable
 adopt-info: set-metadata
 
 environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,7 +70,6 @@ parts:
     source-type: git
     source-branch: ubuntu/resolute
     override-build: |
-      version=$(git describe --tags)
       unset LD_FLAGS
       unset LD_LIBRARY_PATH
       dpkg-buildpackage -b -uc -us -Zgzip -zfast
@@ -81,7 +80,8 @@ parts:
       dcmd mv "../${source}_${version}_${arch}.changes" "${CRAFT_PART_BUILD}/local-debs"
       dpkg -x ${CRAFT_PART_BUILD}/local-debs/console-conf_*.deb ${CRAFT_PART_INSTALL}
       dpkg -x ${CRAFT_PART_BUILD}/local-debs/subiquitycore_*.deb ${CRAFT_PART_INSTALL}
-      # record the version
+      # record the version (use tags as changelog is not being updated)
+      version=$(git describe --tags)
       echo "${version}" > ${CRAFT_PART_INSTALL}/usr/share/subiquity/version-info
     stage:
       - usr/share/subiquity/


### PR DESCRIPTION
The version variable was being set before it was needed, causing it to be unset during the dpkg-buildpackage step. Move the git describe command to just before it's used for recording the version-info file.

Additionally, make the snap grade stable.